### PR TITLE
[FIX] Support dashes in user and repository name

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const regExes = {
   },
   // Otherwise, the escape characters are removed from the expression.
   // eslint-disable-next-line prettier/prettier, no-useless-escape
-  commentUrlParams: new RegExp("(?:https:\/\/)(?:api\.github\.com)\/(?:repos)\/(?<owner>[a-zA-Z0-9-_]+)\/(?<repo>[a-zA-Z0-9-_]+)\/(?:issues)\/(?<issue_number>[0-9]+)"),
+  commentUrlParams: new RegExp("(?:https:\/\/)(?:api\.github\.com)\/(?:repos)\/(?<owner>[a-zA-Z0-9-]+)\/(?<repo>[a-zA-Z0-9-]+)\/(?:issues)\/(?<issue_number>[0-9]+)"),
 };
 
 const configs = {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const regExes = {
   },
   // Otherwise, the escape characters are removed from the expression.
   // eslint-disable-next-line prettier/prettier, no-useless-escape
-  commentUrlParams: new RegExp("(?:https:\/\/)(?:api\.github\.com)\/(?:repos)\/(?<owner>[a-zA-Z0-9-]+)\/(?<repo>[a-zA-Z0-9-]+)\/(?:issues)\/(?<issue_number>[0-9]+)"),
+  commentUrlParams: new RegExp("(?:https:\/\/)(?:api\.github\.com)\/(?:repos)\/(?<owner>[\\w-]+)\/(?<repo>[\\w-]+)\/(?:issues)\/(?<issue_number>[0-9]+)"),
 };
 
 const configs = {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const regExes = {
   },
   // Otherwise, the escape characters are removed from the expression.
   // eslint-disable-next-line prettier/prettier, no-useless-escape
-  commentUrlParams: new RegExp("(?:https:\/\/)(?:api\.github\.com)\/(?:repos)\/(?<owner>\\w+)\/(?<repo>\\w+)\/(?:issues)\/(?<issue_number>[0-9]+)"),
+  commentUrlParams: new RegExp("(?:https:\/\/)(?:api\.github\.com)\/(?:repos)\/(?<owner>[a-zA-Z0-9-_]+)\/(?<repo>[a-zA-Z0-9-_]+)\/(?:issues)\/(?<issue_number>[0-9]+)"),
 };
 
 const configs = {


### PR DESCRIPTION
The `commentUrlRegex` must support dashes since it's a totally valid character in the user/repo name.

Tested against this: https://api.github.com/repos/mbrn/material-table/issues/1592